### PR TITLE
[NCL-5738] Adapt JSON log to proper timestamp

### DIFF
--- a/server/src/main/resources/logging.properties
+++ b/server/src/main/resources/logging.properties
@@ -51,7 +51,7 @@ formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%
 formatter.JSON=org.jboss.logmanager.ext.formatters.LogstashFormatter
 formatter.JSON.properties=metaData,dateFormat
 formatter.JSON.metaData=hostName\=localhost
-formatter.JSON.dateFormat=yyyy-MM-dd'T'HH:mm:ss.SSSZ
+formatter.JSON.dateFormat=yyyy-MM-dd'T'HH:mm:ss.SSSXXX
 
 # POJOs to configure
 pojos=kafka


### PR DESCRIPTION
The timestamp agreed have the timezone specified as: +HH:mm format
instead of +HHmm.

To achieve the former, as per: https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html,
the timezone specifier should be 'SSSXXX' instead of 'SSS'.