### PR TITLE
[NCL-8138] Add support for service account for callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target/
 # IntelliJ
 *.iml
 .idea
+
+# file produced by unit test
+server/console.log

--- a/README.md
+++ b/README.md
@@ -17,3 +17,24 @@ java -jar server/target/server-0.4-SNAPSHOT-jar-with-dependencies.jar -h
 Example using Kafka destination: -kp enables Kafka, -pl defines is as the destination where the compelte log must be written.
 
     java -jar server/target/server-0.4-SNAPSHOT-jar-with-dependencies.jar -kp $PWD/kafka.properties -pl KAFKA
+
+
+Keycloak Client
+===============
+The build-agent sends a callback on completion to the original caller. The callback needs to be authenticated to be
+accepted by the original caller. To obtain the proper Authorization access token for the callback, use the CLI option:
+```
+-keycloakClientConfigFile=<filename>
+```
+
+The filename should have the following content:
+```json
+{
+    "url": "https://keycloak-url",
+    "realm": "realm",
+    "clientId": "client-id",
+    "clientSecret": "client-secret"
+}
+```
+
+Only client credentials flow (service account authentication) is supported at this moment.

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>slf4j-jboss-logmanager</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-authz-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/common/src/main/java/org/jboss/pnc/buildagent/common/security/KeycloakClient.java
+++ b/common/src/main/java/org/jboss/pnc/buildagent/common/security/KeycloakClient.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.buildagent.common.security;
+
+import org.apache.http.impl.client.HttpClients;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.Configuration;
+
+import java.util.Collections;
+
+/**
+ * KeycloakClient to get an access token from the OIDC server to send to authenticated endpoints.
+ * It only supports service account clientId / clientSecret (client credentials flow) for now but can easily be changed
+ * in the future to support other styles of authentication.
+ */
+public class KeycloakClient {
+
+    private final String url;
+    private final String realm;
+    private final String clientId;
+    private final String clientSecret;
+
+    public KeycloakClient(String url, String realm, String clientId, String clientSecret) {
+        this.url = url;
+        this.realm = realm;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    public KeycloakClient(KeycloakClientConfiguration configuration) {
+        this.url = configuration.getUrl();
+        this.realm = configuration.getRealm();
+        this.clientId = configuration.getClientId();
+        this.clientSecret = configuration.getClientSecret();
+    }
+
+    /**
+     * Get a fresh access token from the OIDC server
+     * @return access token
+     */
+    public String getAccessToken() {
+        final Configuration configuration = new Configuration(
+                url,
+                realm,
+                clientId,
+                Collections.singletonMap("secret", clientSecret),
+                HttpClients.createDefault());
+
+        return AuthzClient.create(configuration).obtainAccessToken().getToken();
+    }
+}

--- a/common/src/main/java/org/jboss/pnc/buildagent/common/security/KeycloakClientConfiguration.java
+++ b/common/src/main/java/org/jboss/pnc/buildagent/common/security/KeycloakClientConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.buildagent.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
+
+/**
+ * DTO for Keycloak Client Configuration; it's a companion class for KeycloakClient
+ */
+public class KeycloakClientConfiguration {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+
+    private String url;
+    private String realm;
+    private String clientId;
+    private String clientSecret;
+
+    /**
+     * Parse a JSON file containing the appropriate configuration to produce a KeycloakClientConfiguration
+     *
+     * @param file to parse
+     * @return KeycloakClientConfiguration
+     * @throws KeycloakClientConfigurationException if parsing went wrong
+     */
+    public static KeycloakClientConfiguration parseJson(File file) throws KeycloakClientConfigurationException {
+        try {
+            return OBJECT_MAPPER.readValue(file, KeycloakClientConfiguration.class);
+        } catch (Exception e) {
+            throw new KeycloakClientConfigurationException(e.getMessage());
+        }
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+}

--- a/common/src/main/java/org/jboss/pnc/buildagent/common/security/KeycloakClientConfigurationException.java
+++ b/common/src/main/java/org/jboss/pnc/buildagent/common/security/KeycloakClientConfigurationException.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.buildagent.common.security;
+
+public class KeycloakClientConfigurationException extends Exception {
+    public KeycloakClientConfigurationException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/common/src/test/java/org/jboss/pnc/buildagent/common/security/KeycloakClientConfigurationTest.java
+++ b/common/src/test/java/org/jboss/pnc/buildagent/common/security/KeycloakClientConfigurationTest.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.buildagent.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KeycloakClientConfigurationTest {
+
+    @Test
+    public void testConfiguration() throws Exception {
+        String text = "{\"url\": \"https://google.com\"," +
+                       "\"realm\":\"realm\"," +
+                       "\"clientId\": \"clientId\"," +
+                       "\"clientSecret\": \"clientSecret\"}";
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        KeycloakClientConfiguration configuration = objectMapper.readValue(text, KeycloakClientConfiguration.class);
+
+        Assert.assertEquals("https://google.com", configuration.getUrl());
+        Assert.assertEquals("realm", configuration.getRealm());
+        Assert.assertEquals("clientId", configuration.getClientId());
+        Assert.assertEquals("clientSecret", configuration.getClientSecret());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,11 @@
         <artifactId>keycloak-servlet-filter-adapter</artifactId>
         <version>19.0.3</version>
       </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-authz-client</artifactId>
+        <version>19.0.3</version>
+      </dependency>
 
       <!-- Test dependencies -->
       <dependency>

--- a/server/src/main/java/org/jboss/pnc/buildagent/server/HttpInvokerFactory.java
+++ b/server/src/main/java/org/jboss/pnc/buildagent/server/HttpInvokerFactory.java
@@ -6,6 +6,7 @@ import io.undertow.servlet.util.ImmediateInstanceHandle;
 import org.jboss.pnc.buildagent.api.httpinvoke.RetryConfig;
 import org.jboss.pnc.buildagent.common.http.HttpClient;
 import org.jboss.pnc.buildagent.common.http.HeartbeatSender;
+import org.jboss.pnc.buildagent.common.security.KeycloakClient;
 import org.jboss.pnc.buildagent.server.httpinvoker.SessionRegistry;
 import org.jboss.pnc.buildagent.server.servlet.HttpInvoker;
 
@@ -26,17 +27,21 @@ public class HttpInvokerFactory implements InstanceFactory<HttpInvoker> {
     private final RetryConfig retryConfig;
     private final HeartbeatSender heartbeat;
 
+    private final KeycloakClient keycloakClient;
+
     public HttpInvokerFactory(
             Set<ReadOnlyChannel> readOnlyChannels,
             HttpClient httpClient,
             SessionRegistry sessionRegistry,
             RetryConfig retryConfig,
-            HeartbeatSender heartbeat) {
+            HeartbeatSender heartbeat,
+            KeycloakClient keycloakClient) {
         this.readOnlyChannels = readOnlyChannels;
         this.httpClient = httpClient;
         this.sessionRegistry = sessionRegistry;
         this.retryConfig = retryConfig;
         this.heartbeat = heartbeat;
+        this.keycloakClient = keycloakClient;
     }
 
     @Override
@@ -47,7 +52,8 @@ public class HttpInvokerFactory implements InstanceFactory<HttpInvoker> {
                     sessionRegistry,
                     httpClient,
                     retryConfig,
-                    heartbeat));
+                    heartbeat,
+                    keycloakClient));
         } catch (NoSuchAlgorithmException e) {
             throw new InstantiationException("Cannot create HttpInvoker: " + e.getMessage());
         }

--- a/server/src/main/java/org/jboss/pnc/buildagent/server/Main.java
+++ b/server/src/main/java/org/jboss/pnc/buildagent/server/Main.java
@@ -65,6 +65,7 @@ public class Main {
         options.addOption(null, "callbackMaxRetries",true, "How many times to retry failed completion callback.");
         options.addOption(null, "callbackWaitBeforeRetry",true, "How long to wait before completion callback retry (calculated as: attempt x duration-in-millis).");
         options.addOption(null, "keycloakConfig",true, "Path to Keycloak config file. Must be set to enable endpoint protection.");
+        options.addOption(null, "keycloakClientConfig", true, "Path to Keycloak client config file. Must be set to enable callback authentication");
         options.addOption("h", false, "Print this help message.");
 
         CommandLineParser parser = new DefaultParser();
@@ -131,6 +132,7 @@ public class Main {
         int callbackMaxRetries = Integer.parseInt(getOption(cmd, "callbackMaxRetries", "10"));
         long callbackWaitBeforeRetry = Long.parseLong(getOption(cmd, "callbackWaitBeforeRetry", "500"));
         String keycloakConfigFile = getOption(cmd, "keycloakConfig", "");
+        String keycloakClientConfigFile = getOption(cmd, "keycloakClientConfig", "");
 
         org.jboss.pnc.buildagent.server.Options buildAgentOptions = new org.jboss.pnc.buildagent.server.Options(
                 host,
@@ -140,7 +142,8 @@ public class Main {
                 httpInvokerEnabled,
                 callbackMaxRetries,
                 callbackWaitBeforeRetry,
-                keycloakConfigFile);
+                keycloakConfigFile,
+                keycloakClientConfigFile);
 
         new BuildAgentServer(
                 logPath,

--- a/server/src/main/java/org/jboss/pnc/buildagent/server/Options.java
+++ b/server/src/main/java/org/jboss/pnc/buildagent/server/Options.java
@@ -17,6 +17,7 @@ public class Options {
     private final int callbackMaxRetries;
     private final long callbackWaitBeforeRetry;
     private String keycloakConfigFile;
+    private String keycloakClientConfigFile;
 
     public Options(
             String host,
@@ -26,7 +27,8 @@ public class Options {
             boolean httpInvokerEnabled,
             int callbackMaxRetries,
             long callbackWaitBeforeRetry,
-            String keycloakConfigFile) {
+            String keycloakConfigFile,
+            String keycloakClientConfigFile) {
         this.host = host;
         this.bindPath = bindPath;
         this.socketInvokerEnabled = socketInvokerEnabled;
@@ -34,6 +36,7 @@ public class Options {
         this.callbackMaxRetries = callbackMaxRetries;
         this.callbackWaitBeforeRetry = callbackWaitBeforeRetry;
         this.keycloakConfigFile = keycloakConfigFile;
+        this.keycloakClientConfigFile = keycloakClientConfigFile;
 
         if (bindPort == 0) {
             port = findFirstFreePort();
@@ -80,5 +83,9 @@ public class Options {
 
     public String getKeycloakConfigFile() {
         return keycloakConfigFile;
+    }
+
+    public String getKeycloakClientConfigFile() {
+        return keycloakClientConfigFile;
     }
 }

--- a/server/src/test/java/org/jboss/pnc/buildagent/server/TermdServer.java
+++ b/server/src/test/java/org/jboss/pnc/buildagent/server/TermdServer.java
@@ -74,6 +74,7 @@ public class TermdServer {
                     !enableSocketInvoker,
                     10,
                     500,
+                    "",
                     "");
             Map<String, String> mdcMap = new HashMap<>();
             mdcMap.put("ctx", RandomUtils.randString(6));

--- a/server/src/test/java/org/jboss/pnc/buildagent/server/TestPathMappings.java
+++ b/server/src/test/java/org/jboss/pnc/buildagent/server/TestPathMappings.java
@@ -46,7 +46,7 @@ public class TestPathMappings {
     public void serverShouldListenOnRoot() throws BuildAgentException, InterruptedException, IOException {
         Map<String, String> mdcMap = new HashMap<>();
         mdcMap.put("ctx", RandomUtils.randString(8));
-        Options options = new Options(HOST, 0, "", true, false, 3, 100, "");
+        Options options = new Options(HOST, 0, "", true, false, 3, 100, "", "");
 
         BuildAgentServer buildAgent = new BuildAgentServer(Optional.empty(), Optional.empty(), new IoLoggerName[0], options, mdcMap);
 
@@ -64,7 +64,7 @@ public class TestPathMappings {
         Map<String, String> mdcMap = new HashMap<>();
         mdcMap.put("ctx", RandomUtils.randString(8));
         String contextPath = "ctx-path";
-        Options options = new Options(HOST, 0, "/" + contextPath, true, false,3, 100, "");
+        Options options = new Options(HOST, 0, "/" + contextPath, true, false,3, 100, "", "");
         BuildAgentServer buildAgent = new BuildAgentServer(Optional.empty(), Optional.empty(), new IoLoggerName[0], options, mdcMap);
 
         HttpURLConnection connection200 = connectToUrl(buildAgent.getPort(), contextPath);


### PR DESCRIPTION
The service account is used to obtain an access token from the OIDC server. This token is used for the callback that pnc-build-agent will submit to the caller on completion.

In the past, we could rely on the caller to setup the access token to use on the callback. However, we are going to reduce our access token duration from days to 5 minutes, which means that we cannot use this method anymore.

Instead, we need pnc-build-agent to generate a fresh access token when sending the callback data to the caller.

If the `-keycloakClientConfig` CLI flag is not set, the access token header won't be added in the callback request.