### PR TITLE
Update maven-gpg-plugin to 3.0.1 to avoid ioctl issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,6 +480,20 @@
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
           </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>3.0.1</version>
+              <executions>
+                  <execution>
+                      <id>sign-artifacts</id>
+                      <phase>verify</phase>
+                      <goals>
+                          <goal>sign</goal>
+                      </goals>
+                  </execution>
+              </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
The current issue when releasing is:
```
[INFO] [INFO] --- maven-gpg-plugin:1.6:sign (default) @ parent ---
[INFO] gpg: signing failed: Inappropriate ioctl for device
[INFO] gpg: signing failed: Inappropriate ioctl for device
```
The plugin is likely too old and needs to be updated to 3.0.1

https://stackoverflow.com/questions/53992950/maven-gpg-plugin-failing-with-inappropriate-ioctl-for-device-when-running-unde