### PR TITLE
[NCL-8486] Add ability to verify auth token offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ Example using Kafka destination: -kp enables Kafka, -pl defines is as the destin
 
     java -jar server/target/server-0.4-SNAPSHOT-jar-with-dependencies.jar -kp $PWD/kafka.properties -pl KAFKA
 
+Authentication of Build Agent endpoints
+=======================================
+build-agent can be configured to require an OIDC token for some endpoints. This is done by either providing the `keycloakConfigurationFile` or the `keycloakOfflineConfigurationFile`.
+
+The `keycloakConfigurationFile` follows the [keycloak.json](https://www.keycloak.org/docs/latest/securing_apps/) format and uses the discovery url ({auth url}/auth/realms/{realm}/.well-known/openid-configuration) to find the urls, public keys, and issuer information to validate the token.
+
+In contrast, the `keycloakOfflineConfigurationFile` is used to validate the token using offline techniques only using the public key (obtained from {auth url}/auth/realms/{realm}) and the issuer url only. This is useful when we run build-agent inside a firewall that limits outgoing connections to other servers. The format of the file to provide is:
+```json
+{
+  "publicKey": "public-key",
+  "authServerUrl": "{auth-url}/auth/realms/{realm}"
+}
+```
+
+If both options are specified, only the offline one will be used.
 
 Keycloak Client
 ===============

--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,24 @@
         <version>19.0.3</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-api</artifactId>
+        <version>0.12.3</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-impl</artifactId>
+        <version>0.12.5</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-jackson</artifactId>
+        <version>0.12.5</version>
+        <scope>runtime</scope>
+      </dependency>
+
       <!-- Test dependencies -->
       <dependency>
         <groupId>junit</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -108,8 +108,20 @@
       <artifactId>keycloak-servlet-filter-adapter</artifactId>
     </dependency>
 
-
-
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/server/src/main/java/org/jboss/pnc/buildagent/server/KeycloakOfflineOIDCFilter.java
+++ b/server/src/main/java/org/jboss/pnc/buildagent/server/KeycloakOfflineOIDCFilter.java
@@ -1,0 +1,65 @@
+package org.jboss.pnc.buildagent.server;
+
+import com.fasterxml.jackson.core.exc.StreamReadException;
+import com.fasterxml.jackson.databind.DatabindException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Logger;
+
+import static org.keycloak.adapters.servlet.KeycloakOIDCFilter.CONFIG_FILE_PARAM;
+
+/**
+ * Alternative implementation of KeycloakOIDCFilter, which does not use the .well-known/openid-configuration endpoint
+ * and instead validates the authentication token offline using jjwt and the provided realm-public-key
+ */
+public class KeycloakOfflineOIDCFilter implements Filter {
+
+    private final static Logger log = Logger.getLogger("" + KeycloakOfflineOIDCFilter.class);
+    private KeycloakOfflineOIDCFilterConfiguration configuration;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        Filter.super.init(filterConfig);
+
+        String fp = filterConfig.getInitParameter(CONFIG_FILE_PARAM);
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            configuration = objectMapper.readValue(new File(fp), KeycloakOfflineOIDCFilterConfiguration.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain filterChain) throws IOException, ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
+        String authToken = request.getHeader("Authorization").replace("Bearer", "").trim();
+        try {
+            KeycloakOfflineTokenVerifier.verify(authToken, configuration.getPublicKey(), configuration.getAuthServerUrl());
+        } catch (Exception e) {
+            log.warning("Authorization failed with error: " + e);
+            response.sendError(403);
+        }
+    }
+
+
+    @Override
+    public void destroy() {
+        Filter.super.destroy();
+    }
+}

--- a/server/src/main/java/org/jboss/pnc/buildagent/server/KeycloakOfflineOIDCFilterConfiguration.java
+++ b/server/src/main/java/org/jboss/pnc/buildagent/server/KeycloakOfflineOIDCFilterConfiguration.java
@@ -1,0 +1,36 @@
+package org.jboss.pnc.buildagent.server;
+
+public class KeycloakOfflineOIDCFilterConfiguration {
+
+    /**
+     * The public key of the realm (realm-public-key), as specified in the {auth url}/auth/realms/{realm}
+     */
+    private String publicKey;
+
+
+    /**
+     * The auth server url: should be in format {auth url}/auth/realms/{realm} (similar to how Quarkus auth wants it)
+     */
+    private String authServerUrl;
+
+    public KeycloakOfflineOIDCFilterConfiguration(String publicKey, String authServerUrl) {
+        this.publicKey = publicKey;
+        this.authServerUrl = authServerUrl;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public String getAuthServerUrl() {
+        return authServerUrl;
+    }
+
+    public void setAuthServerUrl(String authServerUrl) {
+        this.authServerUrl = authServerUrl;
+    }
+}

--- a/server/src/main/java/org/jboss/pnc/buildagent/server/KeycloakOfflineTokenVerifier.java
+++ b/server/src/main/java/org/jboss/pnc/buildagent/server/KeycloakOfflineTokenVerifier.java
@@ -1,0 +1,57 @@
+package org.jboss.pnc.buildagent.server;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+public class KeycloakOfflineTokenVerifier {
+
+    /**
+     * Verify that the JWT token is valid, given the public key and the auth-server-url
+     * If the JWT token has expired, the verification will fail.
+     * If the verification fails, an exception is thrown.
+     *
+     * @param jwtString     token to verify
+     * @param publicKey     public key of auth issuer: from {auth url}/auth/realms/{realm}
+     * @param authServerUrl auth-server-url in format: {auth url}/auth/realms/{realm}. Used to verify source of token matches the one we want
+     * @throws Exception if verification fails
+     */
+    public static void verify(String jwtString, String publicKey, String authServerUrl) throws Exception {
+
+        // if the public key doesn't match (token is compromised) then this throws an exception.
+        // if the token is expired, this also throws an exception
+        Jws<Claims> jws = parseJwt(jwtString, publicKey);
+
+        String tokenIssuer = jws.getPayload().getIssuer();
+
+        if (!tokenIssuer.equals(authServerUrl)) {
+            throw new RuntimeException("Token issuer " + tokenIssuer + " doesn't match with the configured issuer: " + authServerUrl);
+        }
+    }
+
+    private static Jws<Claims> parseJwt(String jwtString, String publicKey) throws InvalidKeySpecException, NoSuchAlgorithmException {
+
+        PublicKey publicKeyObj = getPublicKeyObject(publicKey);
+
+        return Jwts.parser()
+                .verifyWith(publicKeyObj)
+                .build()
+                .parseSignedClaims(jwtString);
+    }
+
+    private static PublicKey getPublicKeyObject(String publicKey) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        String rsaPublicKey = "-----BEGIN PUBLIC KEY-----" + publicKey + "-----END PUBLIC KEY-----";
+        rsaPublicKey = rsaPublicKey.replace("-----BEGIN PUBLIC KEY-----", "");
+        rsaPublicKey = rsaPublicKey.replace("-----END PUBLIC KEY-----", "");
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(rsaPublicKey));
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        return kf.generatePublic(keySpec);
+    }
+}

--- a/server/src/main/java/org/jboss/pnc/buildagent/server/Main.java
+++ b/server/src/main/java/org/jboss/pnc/buildagent/server/Main.java
@@ -152,6 +152,7 @@ public class Main {
         int callbackMaxRetries = Integer.parseInt(getOption(cmd, "callbackMaxRetries", "10"));
         long callbackWaitBeforeRetry = Long.parseLong(getOption(cmd, "callbackWaitBeforeRetry", "500"));
         String keycloakConfigFile = getOption(cmd, "keycloakConfig", "");
+        String keycloakOfflineConfigFile = getOption(cmd, "keycloakOfflineConfig", "");
         String keycloakClientConfigFile = getOption(cmd, "keycloakClientConfig", "");
 
         String httpReadTimeoutString = getOption(cmd, "httpReadTimeout", null);
@@ -190,6 +191,7 @@ public class Main {
                 callbackWaitBeforeRetry,
                 bifrostUploaderOptions,
                 keycloakConfigFile,
+                keycloakOfflineConfigFile,
                 keycloakClientConfigFile,
                 httpReadTimeout,
                 httpWriteTimeout);

--- a/server/src/main/java/org/jboss/pnc/buildagent/server/Options.java
+++ b/server/src/main/java/org/jboss/pnc/buildagent/server/Options.java
@@ -17,6 +17,11 @@ public class Options {
     private final int callbackMaxRetries;
     private final long callbackWaitBeforeRetry;
     private String keycloakConfigFile;
+
+    /**
+     * Specify this if we want to verify the access token from a request offline
+     */
+    private String keycloakOfflineConfigFile;
     private String keycloakClientConfigFile;
     private final int httpReadTimeout;
     private final int httpWriteTimeout;
@@ -33,6 +38,7 @@ public class Options {
         long callbackWaitBeforeRetry,
         BifrostUploaderOptions bifrostUploaderOptions,
         String keycloakConfigFile,
+        String keycloakOfflineConfigFile,
         String keycloakClientConfigFile,
         int httpReadTimeout,
         int httpWriteTimeout) {
@@ -44,6 +50,7 @@ public class Options {
         this.callbackWaitBeforeRetry = callbackWaitBeforeRetry;
         this.bifrostUploaderOptions = bifrostUploaderOptions;
         this.keycloakConfigFile = keycloakConfigFile;
+        this.keycloakOfflineConfigFile = keycloakOfflineConfigFile;
         this.keycloakClientConfigFile = keycloakClientConfigFile;
         this.httpReadTimeout = httpReadTimeout;
         this.httpWriteTimeout = httpWriteTimeout;
@@ -93,6 +100,10 @@ public class Options {
 
     public String getKeycloakConfigFile() {
         return keycloakConfigFile;
+    }
+
+    public String getKeycloakOfflineConfigFile() {
+        return keycloakOfflineConfigFile;
     }
 
     public String getKeycloakClientConfigFile() {

--- a/server/src/test/java/org/jboss/pnc/buildagent/server/KeycloakOfflineTokenVerifierTest.java
+++ b/server/src/test/java/org/jboss/pnc/buildagent/server/KeycloakOfflineTokenVerifierTest.java
@@ -1,0 +1,118 @@
+package org.jboss.pnc.buildagent.server;
+
+import io.jsonwebtoken.Jwts;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+public class KeycloakOfflineTokenVerifierTest {
+
+    @Test
+    public void testPublicKeyVerification() throws Exception {
+
+        KeyPair kp = generateRSAKeyPair();
+        Instant now = Instant.now();
+        String issuer = "https://rudolph/test";
+
+        String jwtToken = Jwts.builder()
+                .claim("name", "Jane Doe")
+                .claim("email", "jane@example.com")
+                .subject("jane")
+                .id(UUID.randomUUID().toString())
+                .issuer(issuer)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(5, ChronoUnit.MINUTES)))
+                .signWith(kp.getPrivate())
+                .compact();
+
+        KeycloakOfflineTokenVerifier.verify(jwtToken, textPublicKey(kp.getPublic()), issuer);
+    }
+
+    @Test
+    public void testTokenExpired() throws Exception {
+
+        KeyPair kp = generateRSAKeyPair();
+        Instant now = Instant.now();
+        String issuer = "https://rudolph/test";
+
+        // this token has already expired
+        String jwtToken = Jwts.builder()
+                .claim("name", "Jane Doe")
+                .claim("email", "jane@example.com")
+                .subject("jane")
+                .id(UUID.randomUUID().toString())
+                .issuer(issuer)
+                .issuedAt(Date.from(now.minus(10, ChronoUnit.MINUTES)))
+                .expiration(Date.from(now.minus(5, ChronoUnit.MINUTES)))
+                .signWith(kp.getPrivate())
+                .compact();
+
+        // token expired, so this should fail
+        Assert.assertThrows(Exception.class, () -> KeycloakOfflineTokenVerifier.verify(jwtToken, textPublicKey(kp.getPublic()), issuer));
+    }
+
+    @Test
+    public void testWrongPublicKey() throws Exception {
+
+        KeyPair kp = generateRSAKeyPair();
+        KeyPair kpSecond = generateRSAKeyPair();
+
+        Instant now = Instant.now();
+        String issuer = "https://rudolph/test";
+
+        // this token has already expired
+        String jwtToken = Jwts.builder()
+                .claim("name", "Jane Doe")
+                .claim("email", "jane@example.com")
+                .subject("jane")
+                .id(UUID.randomUUID().toString())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(5, ChronoUnit.MINUTES)))
+                .issuer(issuer)
+                .signWith(kp.getPrivate())
+                .compact();
+
+        // use a completely different public key, this verification should fail
+        Assert.assertThrows(Exception.class, () -> KeycloakOfflineTokenVerifier.verify(jwtToken, textPublicKey(kpSecond.getPublic()), issuer));
+    }
+
+    @Test
+    public void testWrongIssuer() throws Exception {
+
+        KeyPair kp = generateRSAKeyPair();
+        Instant now = Instant.now();
+        String issuer = "https://rudolph/test";
+
+        String jwtToken = Jwts.builder()
+                .claim("name", "Jane Doe")
+                .claim("email", "jane@example.com")
+                .subject("jane")
+                .id(UUID.randomUUID().toString())
+                .issuer(issuer)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(5, ChronoUnit.MINUTES)))
+                .signWith(kp.getPrivate())
+                .compact();
+
+        // all good, except with the wrong issuer
+        Assert.assertThrows(Exception.class, () -> KeycloakOfflineTokenVerifier.verify(jwtToken, textPublicKey(kp.getPublic()), "https://booya.com/no"));
+    }
+
+    private KeyPair generateRSAKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(4096);
+        return kpg.generateKeyPair();
+    }
+
+    private String textPublicKey(Key publicKey) {
+        return Base64.getEncoder().encodeToString(publicKey.getEncoded());
+    }
+}

--- a/server/src/test/java/org/jboss/pnc/buildagent/server/TermdServer.java
+++ b/server/src/test/java/org/jboss/pnc/buildagent/server/TermdServer.java
@@ -78,6 +78,7 @@ public class TermdServer {
                     null,
                     "",
                     "",
+                    "",
                     HttpClient.DEFAULT_HTTP_READ,
                     HttpClient.DEFAULT_HTTP_WRITE);
             Map<String, String> mdcMap = new HashMap<>();

--- a/server/src/test/java/org/jboss/pnc/buildagent/server/TestPathMappings.java
+++ b/server/src/test/java/org/jboss/pnc/buildagent/server/TestPathMappings.java
@@ -50,7 +50,7 @@ public class TestPathMappings {
     public void serverShouldListenOnRoot() throws BuildAgentException, InterruptedException, IOException {
         Map<String, String> mdcMap = new HashMap<>();
         mdcMap.put("ctx", RandomUtils.randString(8));
-        Options options = new Options(HOST, 0, "", true, false, 3, 100, null, "", "", DEFAULT_HTTP_READ, DEFAULT_HTTP_WRITE);
+        Options options = new Options(HOST, 0, "", true, false, 3, 100, null, "", "", "", DEFAULT_HTTP_READ, DEFAULT_HTTP_WRITE);
 
         BuildAgentServer buildAgent = new BuildAgentServer(Optional.empty(), Optional.empty(), new IoLoggerName[0], options, mdcMap);
 
@@ -68,7 +68,7 @@ public class TestPathMappings {
         Map<String, String> mdcMap = new HashMap<>();
         mdcMap.put("ctx", RandomUtils.randString(8));
         String contextPath = "ctx-path";
-        Options options = new Options(HOST, 0, "/" + contextPath, true, false,3, 100, null, "", "", DEFAULT_HTTP_READ, DEFAULT_HTTP_WRITE);
+        Options options = new Options(HOST, 0, "/" + contextPath, true, false,3, 100, null, "", "", "", DEFAULT_HTTP_READ, DEFAULT_HTTP_WRITE);
         BuildAgentServer buildAgent = new BuildAgentServer(Optional.empty(), Optional.empty(), new IoLoggerName[0], options, mdcMap);
 
         HttpURLConnection connection200 = connectToUrl(buildAgent.getPort(), contextPath);


### PR DESCRIPTION
This prevents the need to use the auth discovery url to get properties. This is useful when build-agent runs on a firewall that prevents outgoing connections to servers.