### PR TITLE
Fix NPE if callback is null

### DIFF
--- a/server/src/main/java/org/jboss/pnc/buildagent/server/servlet/HttpInvoker.java
+++ b/server/src/main/java/org/jboss/pnc/buildagent/server/servlet/HttpInvoker.java
@@ -157,6 +157,13 @@ public class HttpInvoker extends HttpServlet {
     }
 
     private void onComplete(CommandSession commandSession, Status newStatus, Request callback) {
+
+        // some requests like startSshd don't come with a callback.
+        if (callback == null) {
+            logger.info("No callback with the request. Skipping onComplete");
+            return;
+        }
+
         TaskStatusUpdateEvent.Builder updateEventBuilder = TaskStatusUpdateEvent.newBuilder();
         updateEventBuilder.context(callback.getAttachment());
         String md5;


### PR DESCRIPTION
When build-agent gets a request with no callback (like for startSshd.sh for debug mode), a NullPointerException is thrown.

This commit will skip running any callback logic if the callback is null.