### PR TITLE
Add maven-enforcer-plugin to use deps with jdk 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,12 +282,12 @@
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-servlet-filter-adapter</artifactId>
-        <version>25.0.3</version>
+        <version>19.0.3</version>
       </dependency>
       <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-authz-client</artifactId>
-        <version>26.0.9</version>
+        <version>25.0.6</version>
       </dependency>
       <dependency>
         <groupId>com.unboundid</groupId>
@@ -433,6 +433,35 @@
     </pluginManagement>
 
     <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.5.0</version> <!-- Use the latest stable version available -->
+            <executions>
+                <execution>
+                    <id>enforce-bytecode-version</id>
+                    <goals>
+                        <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                        <rules>
+                            <enforceBytecodeVersion>
+                                <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>
+                            </enforceBytecodeVersion>
+                        </rules>
+                        <fail>true</fail>
+                    </configuration>
+                </execution>
+            </executions>
+            <dependencies>
+                <!-- This dependency adds the extra rules to the standard enforcer plugin -->
+                <dependency>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>extra-enforcer-rules</artifactId>
+                    <version>1.9.0</version>
+                </dependency>
+            </dependencies>
+        </plugin>
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>


### PR DESCRIPTION
    Add maven-enforcer-plugin to use deps with jdk 8

    And revert keycloak-authz-client and keycloak-servlet-filter-adapter
    versions to have dependencies built with jdk 8 only.

    From now on, if there's a dependency update that pulls in JDK > 8,
    maven-enforcer-plugin will complain.
